### PR TITLE
Use tables for parameters listings in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+./scripts/build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: generate
+generate:
+	python ./scripts/generator.py
+
+lint:
+	pylint ./scripts/generator.py
+
+.PHONY: clean
+clean:
+	rm -rf ./generated/*

--- a/aws-cloudwatch.md
+++ b/aws-cloudwatch.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Cloudwatch

--- a/aws-s3.md
+++ b/aws-s3.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from S3

--- a/azure-blob-storage.md
+++ b/azure-blob-storage.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Azure Blob Storage

--- a/azure-eventhub.md
+++ b/azure-eventhub.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Azure Eventhub

--- a/cel.md
+++ b/cel.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from CEL

--- a/entity-analytics.md
+++ b/entity-analytics.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Entity Analytics

--- a/etw.md
+++ b/etw.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from ETW

--- a/filestream.md
+++ b/filestream.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Filestream

--- a/gcp-pubsub.md
+++ b/gcp-pubsub.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from GCP Pub/Sub

--- a/gcs.md
+++ b/gcs.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from GCS

--- a/generated/azure_blob_storage.md
+++ b/generated/azure_blob_storage.md
@@ -9,6 +9,7 @@ can also be gzip compressed.
 
 ### Collecting logs from Custom Azure Blob Storage Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/azure_blob_storage.md
+++ b/generated/azure_blob_storage.md
@@ -11,175 +11,31 @@ can also be gzip compressed.
 
 #### Configuration Parameters
 
-##### Account Name
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Account Name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.   |
+| Client ID (OAuth2) | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.  |
+| Client Secret (OAuth2) | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.  |
+| Containers | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | yaml | This attribute contains the details about a specific container like, name, number_of_workers, poll, poll_interval etc. The attribute 'name' is specific to a container as it describes the container name, while the fields number_of_workers, poll, poll_interval can exist both at the container level and at the global level.  If you have already defined the attributes globally, then you can only specify the container name in this yaml config. If you want to override any specific attribute for a container, then, you can define it here. Any attribute defined in the yaml will override the global definitions.  Please see the relevant [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-containers) for further information.   |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Maximum number of workers | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | integer | Determines how many workers are spawned per container.  |
+| Collect logs using OAuth2 authentication | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.  |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Polling | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Determines if the container will be continuously polled for new documents.  |
+| Polling interval | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Determines the time interval between polling operations.  |
+| Preserve original event | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Preserves a raw copy of the original event, added to the field `event.original`  |
+| Service Account Key | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | This attribute contains the access key, found under the Access keys section on Azure Cloud, under the respective storage account. A single storage account can contain multiple containers, and they will all use this common access key.   |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
+| Tenant ID (OAuth2) | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.  |
 
-*description*: This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
+#### Advanced Configuration Parameters
 
-##### Client ID (OAuth2)
-*Optional*
-
-*type*: text
-
-*description*: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
-##### Client Secret (OAuth2)
-*Optional*
-
-*type*: password
-
-*description*: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
-##### Containers
-*Required*
-*type*: yaml
-
-*description*: This attribute contains the details about a specific container like, name, number_of_workers, poll, poll_interval etc. The attribute 'name' is specific to a container as it describes the container name, while the fields number_of_workers, poll, poll_interval can exist both at the container level and at the global level.  If you have already defined the attributes globally, then you can only specify the container name in this yaml config. If you want to override any specific attribute for a container, then, you can define it here. Any attribute defined in the yaml will override the global definitions.  Please see the relevant [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-containers) for further information.
-
-##### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-##### Maximum number of workers
-*Optional*
-
-*type*: integer
-
-*description*: Determines how many workers are spawned per container.
-##### Collect logs using OAuth2 authentication
-*Required*
-*type*: bool
-
-*description*: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Polling
-*Optional*
-
-*type*: bool
-
-*description*: Determines if the container will be continuously polled for new documents.
-##### Polling interval
-*Optional*
-
-*type*: text
-
-*description*: Determines the time interval between polling operations.
-##### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`
-##### Service Account Key
-*Optional*
-
-*type*: password
-
-*description*: This attribute contains the access key, found under the Access keys section on Azure Cloud, under the respective storage account. A single storage account can contain multiple containers, and they will all use this common access key.
-
-##### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-##### Tenant ID (OAuth2)
-*Optional*
-
-*type*: text
-
-*description*: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
-
-#### Advanced Parameters
-
-#### Account Name
-*Required*
-*type*: text
-
-*description*: This attribute is required for various internal operations with respect to authentication, creating service clients and blob clients which are used internally for various processing purposes.
-
-#### Client ID (OAuth2)
-*Optional*
-
-*type*: text
-
-*description*: Client ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
-#### Client Secret (OAuth2)
-*Optional*
-
-*type*: password
-
-*description*: Client Secret of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
-#### Containers
-*Required*
-*type*: yaml
-
-*description*: This attribute contains the details about a specific container like, name, number_of_workers, poll, poll_interval etc. The attribute 'name' is specific to a container as it describes the container name, while the fields number_of_workers, poll, poll_interval can exist both at the container level and at the global level.  If you have already defined the attributes globally, then you can only specify the container name in this yaml config. If you want to override any specific attribute for a container, then, you can define it here. Any attribute defined in the yaml will override the global definitions.  Please see the relevant [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-containers) for further information.
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Maximum number of workers
-*Optional*
-
-*type*: integer
-
-*description*: Determines how many workers are spawned per container.
-#### Collect logs using OAuth2 authentication
-*Required*
-*type*: bool
-
-*description*: To collect logs using OAuth2 authentication enable the toggle switch. By default, it will collect logs using service account key or URI.
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Polling
-*Optional*
-
-*type*: bool
-
-*description*: Determines if the container will be continuously polled for new documents.
-#### Polling interval
-*Optional*
-
-*type*: text
-
-*description*: Determines the time interval between polling operations.
-#### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`
-#### Service Account Key
-*Optional*
-
-*type*: password
-
-*description*: This attribute contains the access key, found under the Access keys section on Azure Cloud, under the respective storage account. A single storage account can contain multiple containers, and they will all use this common access key.
-
-#### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-#### Tenant ID (OAuth2)
-*Optional*
-
-*type*: text
-
-*description*: Tenant ID of Azure Account. This is required if 'Collect logs using OAuth2 authentication' is enabled.
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Expand Event List From Field | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | If the file-set using this input expects to receive multiple messages bundled under a specific field or an array of objects then the config option for 'expand_event_list_from_field' can be specified. This setting will be able to split the messages under the group value into separate events. This can be specified at the global level or at the container level. For more info please refer to the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-azure-blob-storage.html#attrib-expand_event_list_from_field).   |
+| File Selectors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | If the container will have events that correspond to files that this integration shouldn’t process, file_selectors can be used to limit the files that are downloaded.  This is a list of selectors which is made up of regex patters. The regex should match the container filepath.  Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed.   |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Service Account URI | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | This attribute contains the connection string, found under the Access keys section on Azure Cloud, under the respective storage account. A single storage account can contain multiple containers, and they will all use this common connection string.   |
+| Storage URL | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Use this attribute to specify a custom storage URL if required. By default it points to azure cloud storage. Only use this if there is a specific need to connect to a different environment where blob storage is available. URL format : {{protocol}}://{{account_name}}.{{storage_uri}}.   |
+| Timestamp Epoch | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | integer |   |
 

--- a/generated/azure_logs.md
+++ b/generated/azure_logs.md
@@ -11,79 +11,30 @@ within Kibana. It helps users gain insights into their Azure environment for sec
 
 #### Configuration Parameters
 
-##### Connection String
-*Required*
-*type*: password
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Connection String | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | password | The connection string required to communicate with Event Hubs. See [Get an Event Hubs connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string) to learn more.  |
+| Consumer Group | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index.  You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).  |
+| Event Hub Name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | The event hub name that contains the logs to ingest. Do not use the event hub namespace here. Elastic recommends using one event hub for each integration. Visit [Create an event hub](https://docs.elastic.co/integrations/azure#create-an-event-hub) to learn more. Use event hub names up to 30 characters long to avoid compatibility issues.  |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The ingest pipeline ID to use for processing the data. If provided, replaces the default pipeline for this integration.  |
+| Storage Account | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | The name of the storage account where the consumer group's state/offsets will be stored and updated.  |
+| Storage Account Key | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | password | The storage account key, this key will be used to authorize access to data in your storage account.  |
 
-*description*: The connection string required to communicate with Event Hubs. See [Get an Event Hubs connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string) to learn more.
-##### Consumer Group
-*Required*
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: 
-##### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index.  You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-##### Event Hub Name
-*Required*
-*type*: text
-
-*description*: The event hub name that contains the logs to ingest. Do not use the event hub namespace here. Elastic recommends using one event hub for each integration. Visit [Create an event hub](https://docs.elastic.co/integrations/azure#create-an-event-hub) to learn more. Use event hub names up to 30 characters long to avoid compatibility issues.
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The ingest pipeline ID to use for processing the data. If provided, replaces the default pipeline for this integration.
-##### Storage Account
-*Required*
-*type*: text
-
-*description*: The name of the storage account where the consumer group's state/offsets will be stored and updated.
-##### Storage Account Key
-*Required*
-*type*: password
-
-*description*: The storage account key, this key will be used to authorize access to data in your storage account.
-
-#### Advanced Parameters
-
-#### Connection String
-*Required*
-*type*: password
-
-*description*: The connection string required to communicate with Event Hubs. See [Get an Event Hubs connection string](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-get-connection-string) to learn more.
-#### Consumer Group
-*Required*
-*type*: text
-
-*description*: 
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index.  You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-#### Event Hub Name
-*Required*
-*type*: text
-
-*description*: The event hub name that contains the logs to ingest. Do not use the event hub namespace here. Elastic recommends using one event hub for each integration. Visit [Create an event hub](https://docs.elastic.co/integrations/azure#create-an-event-hub) to learn more. Use event hub names up to 30 characters long to avoid compatibility issues.
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The ingest pipeline ID to use for processing the data. If provided, replaces the default pipeline for this integration.
-#### Storage Account
-*Required*
-*type*: text
-
-*description*: The name of the storage account where the consumer group's state/offsets will be stored and updated.
-#### Storage Account Key
-*Required*
-*type*: password
-
-*description*: The storage account key, this key will be used to authorize access to data in your storage account.
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Migrate checkpoint information | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | (Processor v2 only) Flag to control if the processor should perform  the checkpoint information migration from processor v1 to v2 at startup. The checkpoint migration converts the checkpoint information from the v1 format to the v2 format. Default is `false`, which means the processor will not perform the checkpoint migration.  |
+| Partition receive count | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | (Processor v2 only) Maximum number of messages from the event hub to wait for before processing them. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `100` messages.  |
+| Partition receive timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | (Processor v2 only) Maximum time to wait before processing the messages received from the event hub. The partition consumer waits up to a "receive count" or a "receive timeout", whichever comes first. Default is `5` seconds.  |
+| Processor start position | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | (Processor v2 only) Controls from what position in the event hub the processor should start processing messages for all partitions. Possible values are `earliest` and `latest`. `earliest` starts processing messages from the last checkpoint, or the beginning of the event hub if no checkpoint is available. `latest` starts processing messages from the the latest event in the event hub and continues to process new events as they arrive. Default is `earliest`.  |
+| Processor update interval | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | (Processor v2 only) How often the processor should attempt to claim partitions. Default is `10` seconds.  |
+| Processor version | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The processor version that the integration should use. Possible values are `v1` and `v2` (preview).  The v2 event hub processor is in preview, so using the v1 processor is recommended for typical use cases. Default is `v1`.  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This runs in the agent before the logs are parsed. Check [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Resource Manager Endpoint | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Azure Resource Manager endpoint to use for authentication.  |
+| Sanitizes New Lines | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Removes new lines in logs to ensure proper formatting of JSON data and avoid parsing issues during processing.   |
+| Sanitizes Single Quotes | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Replaces single quotes with double quotes (single quotes inside double quotes are omitted) in logs to ensure proper formatting of JSON data and avoid parsing issues during processing.   |
+| Storage Account Container | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The storage account container where the integration stores the checkpoint data for the event hub / consumer group. It is an advanced option to use with extreme care. If you are using the [processor_version](https://www.elastic.co/guide/en/integrations/current/azure_logs.html#azure_logs-event-hub-processor-options) v1 (default option), you MUST use a dedicated storage account container for each event hub / consumer group pair. For information about container name restrictions, please refer to the [Container Names](https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names) section in Microsoft's documentation. If you don't specify a container name, the integration will automatically generate a default one for you.  |
+| Tags | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
 

--- a/generated/azure_logs.md
+++ b/generated/azure_logs.md
@@ -9,6 +9,7 @@ within Kibana. It helps users gain insights into their Azure environment for sec
 
 ### Collecting logs from Custom Azure Logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/cel.md
+++ b/generated/cel.md
@@ -8,6 +8,7 @@ processes data. This enables advanced users to create flexible data collection p
 
 ### Collecting logs from Custom API using Common Expression Language
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/cel.md
+++ b/generated/cel.md
@@ -10,225 +10,58 @@ processes data. This enables advanced users to create flexible data collection p
 
 #### Configuration Parameters
 
-##### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-##### Delete redacted fields
-*Required*
-*type*: bool
-
-*description*: The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will
-leak information, the fields can be deleted from logging by setting this configuration to true.
-
-##### Digest No Challenge Reuse
-*Optional*
-
-*type*: bool
-
-*description*: Selecting no challenge reuse prevents the transport from reusing digest challenges
-##### Digest Auth Password
-*Optional*
-
-*type*: password
-
-*description*: The password to be used with Digest Auth headers
-##### Digest Auth Username
-*Optional*
-
-*type*: text
-
-*description*: The username to be used with Digest Auth headers
-##### OAuth2 Client ID
-*Optional*
-
-*type*: text
-
-*description*: Client ID used for OAuth2 authentication
-##### OAuth2 Client Secret
-*Optional*
-
-*type*: password
-
-*description*: Client secret used for OAuth2 authentication
-##### OAuth2 Token URL
-*Optional*
-
-*type*: text
-
-*description*: The URL endpoint that will be used to generate the tokens during the oAuth2 flow. It is required if no oauth_custom variable is set or provider is not specified in oauth_custom variable.
-##### Basic Auth Password
-*Optional*
-
-*type*: password
-
-*description*: The password to be used with Basic Auth headers
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### The CEL program to be run for each polling.
-*Required*
-*type*: textarea
-
-*description*: Program is the CEL program that is executed each polling period to get and transform the API data.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_execution).
-
-##### Redacted fields
-*Optional*
-
-*type*: text
-
-*description*: Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included
-in logs. This may leak secrets, so list sensitive state fields in this configuration.
-
-##### Defined Regular Expressions
-*Optional*
-
-*type*: yaml
-
-*description*: Regexps is the set of regular expression to be made available to the program by name. The syntax used is [RE2](https://github.com/google/re2/wiki/Syntax).
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#regexp-cel).
-
-##### Resource Interval
-*Required*
-*type*: text
-
-*description*: How often the API is polled, supports seconds, minutes and hours.
-##### Resource URL
-*Required*
-*type*: text
-
-*description*: i.e. scheme://host:port/path
-##### Initial CEL evaluation state
-*Optional*
-
-*type*: yaml
-
-*description*: State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#input-state-cel).
-
-##### Basic Auth Username
-*Optional*
-
-*type*: text
-
-*description*: The username to be used with Basic Auth headers
-
-#### Advanced Parameters
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Delete redacted fields
-*Required*
-*type*: bool
-
-*description*: The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will
-leak information, the fields can be deleted from logging by setting this configuration to true.
-
-#### Digest No Challenge Reuse
-*Optional*
-
-*type*: bool
-
-*description*: Selecting no challenge reuse prevents the transport from reusing digest challenges
-#### Digest Auth Password
-*Optional*
-
-*type*: password
-
-*description*: The password to be used with Digest Auth headers
-#### Digest Auth Username
-*Optional*
-
-*type*: text
-
-*description*: The username to be used with Digest Auth headers
-#### OAuth2 Client ID
-*Optional*
-
-*type*: text
-
-*description*: Client ID used for OAuth2 authentication
-#### OAuth2 Client Secret
-*Optional*
-
-*type*: password
-
-*description*: Client secret used for OAuth2 authentication
-#### OAuth2 Token URL
-*Optional*
-
-*type*: text
-
-*description*: The URL endpoint that will be used to generate the tokens during the oAuth2 flow. It is required if no oauth_custom variable is set or provider is not specified in oauth_custom variable.
-#### Basic Auth Password
-*Optional*
-
-*type*: password
-
-*description*: The password to be used with Basic Auth headers
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### The CEL program to be run for each polling.
-*Required*
-*type*: textarea
-
-*description*: Program is the CEL program that is executed each polling period to get and transform the API data.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_execution).
-
-#### Redacted fields
-*Optional*
-
-*type*: text
-
-*description*: Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included
-in logs. This may leak secrets, so list sensitive state fields in this configuration.
-
-#### Defined Regular Expressions
-*Optional*
-
-*type*: yaml
-
-*description*: Regexps is the set of regular expression to be made available to the program by name. The syntax used is [RE2](https://github.com/google/re2/wiki/Syntax).
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#regexp-cel).
-
-#### Resource Interval
-*Required*
-*type*: text
-
-*description*: How often the API is polled, supports seconds, minutes and hours.
-#### Resource URL
-*Required*
-*type*: text
-
-*description*: i.e. scheme://host:port/path
-#### Initial CEL evaluation state
-*Optional*
-
-*type*: yaml
-
-*description*: State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#input-state-cel).
-
-#### Basic Auth Username
-*Optional*
-
-*type*: text
-
-*description*: The username to be used with Basic Auth headers
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Delete redacted fields | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will leak information, the fields can be deleted from logging by setting this configuration to true.   |
+| Digest No Challenge Reuse | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Selecting no challenge reuse prevents the transport from reusing digest challenges  |
+| Digest Auth Password | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The password to be used with Digest Auth headers  |
+| Digest Auth Username | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The username to be used with Digest Auth headers  |
+| OAuth2 Client ID | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Client ID used for OAuth2 authentication  |
+| OAuth2 Client Secret | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | Client secret used for OAuth2 authentication  |
+| OAuth2 Token URL | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The URL endpoint that will be used to generate the tokens during the oAuth2 flow. It is required if no oauth_custom variable is set or provider is not specified in oauth_custom variable.  |
+| Basic Auth Password | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The password to be used with Basic Auth headers  |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| The CEL program to be run for each polling. | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | textarea | Program is the CEL program that is executed each polling period to get and transform the API data. More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_execution).   |
+| Redacted fields | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included in logs. This may leak secrets, so list sensitive state fields in this configuration.   |
+| Defined Regular Expressions | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Regexps is the set of regular expression to be made available to the program by name. The syntax used is [RE2](https://github.com/google/re2/wiki/Syntax). More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#regexp-cel).   |
+| Resource Interval | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | How often the API is polled, supports seconds, minutes and hours.  |
+| Resource URL | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | i.e. scheme://host:port/path  |
+| Initial CEL evaluation state | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists. More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#input-state-cel).   |
+| Basic Auth Username | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The username to be used with Basic Auth headers  |
+
+#### Advanced Configuration Parameters
+
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Allowed environment variables | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The CEL program may access environment variables via the `env` global. This lists the environment variables that are made available to the program during evaluation. See the [`allowed_environment` documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#environ-cel) for details.   |
+| Condition | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.   |
+| Enable request tracing | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.   |
+| OAuth2 Azure Resource | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Optional setting for the accessed WebAPI resource when using azure provider.  |
+| OAuth2 Azure Tenant ID | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Optional setting used for authentication when using Azure provider. Since it is used in the process to generate the token_url, it can’t be used in combination with it.  |
+| OAuth2 Endpoint Params | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Set of values that will be sent on each resource to the token_url. Each param key can have multiple values. Can be set for all providers except google.  |
+| OAuth2 Google Credentials File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The full path to the credentials file for Google.  |
+| OAuth2 Google Credentials JSON | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Your Google credentials information as raw JSON.  |
+| OAuth2 Google Delegated account | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Email of the delegated account used to create the credentials (usually an admin).  |
+| OAuth2 Google JWT File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Full path to the JWT Account Key file for Google.  |
+| OAuth2 Google JWT JSON | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Your Google JWT information as raw JSON.  |
+| OAuth2 Okta JWT File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Full path to the JWT account private key file for Okta.  |
+| OAuth2 Okta JWT JSON | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Your Okta JWT private key as raw JSON.  |
+| OAuth2 Okta JWT PEM | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Your Okta JWT private key encoded as a PEM block.  |
+| OAuth2 Provider | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Used to configure supported oAuth2 providers. Each supported provider will require specific settings. It is not set by default. Supported providers are "azure" and "google".  |
+| OAuth2 Scopes | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | A list of scopes that will be resourceed during the oAuth2 flow. It is optional for all providers.  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Resource Proxy | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | This specifies proxy configuration in the form of `http[s]://<user>:<password>@<server name/ip>:<port>`.  |
+| Resource Rate Limit Burst | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum burst size. Burst is the maximum number of resource requests that can be made above the overall rate limit.  |
+| Resource Rate Limit | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The value of the response that specifies the total limit.  |
+| Resource Redirect Forward Headers | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | When set to true resource headers are forwarded in case of a redirect. Default is "false".  |
+| Resource Redirect Headers Ban List | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | When Redirect Forward Headers is set to true, all headers except the ones defined in this list will be forwarded. All headers are forwarded by default.  |
+| Resource Redirect Max Redirects | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum number of redirects to follow for a resource. Default is "10".  |
+| Resource Retry Max Attempts | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum number of retries for the HTTP client. Default is "5".  |
+| Resource Retry Wait Max | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum time to wait before a retry is attempted. Default is "60s".  |
+| Resource Retry Wait Min | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The minimum time to wait before a retry is attempted. Default is "1s".  |
+| Resource SSL Configuration | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | i.e. certificate_authorities, supported_protocols, verification_mode etc, more examples found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config)  |
+| Resource Timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Duration before declaring that the HTTP client connection has timed out. Valid time units are ns, us, ms, s, m, h. Default is "30"s.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| XML Schema Definitions (XSD) for XML documents. | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | textarea | The XSD needed for correct parsing and ingestion of XML documents using decode_xml CEL extension. More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#xsd-cel).   |
 

--- a/generated/gcp_metrics.md
+++ b/generated/gcp_metrics.md
@@ -11,97 +11,20 @@ collection and typically requires custom ingest pipelines for pre-ingest data pr
 
 #### Configuration Parameters
 
-##### Credentials File
-*Optional*
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Credentials File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| Credentials Json | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| Exclude Labels | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Exclude additional labels from metrics  |
+| GCP Metrics | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Project Id | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| GCP Regions | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| GCP Service | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| GCP Zone | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
 
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: 
-##### Credentials Json
-*Optional*
-
-*type*: text
-
-*description*: 
-##### Exclude Labels
-*Optional*
-
-*type*: bool
-
-*description*: Exclude additional labels from metrics
-##### GCP Metrics
-*Required*
-*type*: text
-
-*description*: 
-##### Project Id
-*Required*
-*type*: text
-
-*description*: 
-##### GCP Regions
-*Optional*
-
-*type*: text
-
-*description*: 
-##### GCP Service
-*Required*
-*type*: text
-
-*description*: 
-##### GCP Zone
-*Optional*
-
-*type*: text
-
-*description*: 
-
-#### Advanced Parameters
-
-#### Credentials File
-*Optional*
-
-*type*: text
-
-*description*: 
-#### Credentials Json
-*Optional*
-
-*type*: text
-
-*description*: 
-#### Exclude Labels
-*Optional*
-
-*type*: bool
-
-*description*: Exclude additional labels from metrics
-#### GCP Metrics
-*Required*
-*type*: text
-
-*description*: 
-#### Project Id
-*Required*
-*type*: text
-
-*description*: 
-#### GCP Regions
-*Optional*
-
-*type*: text
-
-*description*: 
-#### GCP Service
-*Required*
-*type*: text
-
-*description*: 
-#### GCP Zone
-*Optional*
-
-*type*: text
-
-*description*: 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Period | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
 

--- a/generated/gcp_metrics.md
+++ b/generated/gcp_metrics.md
@@ -9,6 +9,7 @@ collection and typically requires custom ingest pipelines for pre-ingest data pr
 
 ### Collecting logs from GCP Metrics Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/gcp_pubsub.md
+++ b/generated/gcp_pubsub.md
@@ -8,6 +8,7 @@ Stackdriver logs. This input is designed for continuous processing, handling cre
 
 ### Collecting logs from Custom Google Pub/Sub Logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/gcp_pubsub.md
+++ b/generated/gcp_pubsub.md
@@ -10,99 +10,24 @@ Stackdriver logs. This input is designed for continuous processing, handling cre
 
 #### Configuration Parameters
 
-##### Credentials File
-*Optional*
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Credentials File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Path to a JSON file containing the credentials and key used to subscribe.  |
+| Credentials JSON | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | JSON blob containing the credentials and key used to subscribe.  |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Project ID | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Subscription Create | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | If true, the integration will create the subscription on start.  |
+| Subscription Name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Topic | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
 
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: Path to a JSON file containing the credentials and key used to subscribe.
-##### Credentials JSON
-*Optional*
-
-*type*: password
-
-*description*: JSON blob containing the credentials and key used to subscribe.
-##### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Project ID
-*Required*
-*type*: text
-
-*description*: 
-##### Subscription Create
-*Optional*
-
-*type*: bool
-
-*description*: If true, the integration will create the subscription on start.
-##### Subscription Name
-*Required*
-*type*: text
-
-*description*: 
-##### Topic
-*Required*
-*type*: text
-
-*description*: 
-
-#### Advanced Parameters
-
-#### Credentials File
-*Optional*
-
-*type*: text
-
-*description*: Path to a JSON file containing the credentials and key used to subscribe.
-#### Credentials JSON
-*Optional*
-
-*type*: password
-
-*description*: JSON blob containing the credentials and key used to subscribe.
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Project ID
-*Required*
-*type*: text
-
-*description*: 
-#### Subscription Create
-*Optional*
-
-*type*: bool
-
-*description*: If true, the integration will create the subscription on start.
-#### Subscription Name
-*Required*
-*type*: text
-
-*description*: 
-#### Topic
-*Required*
-*type*: text
-
-*description*: 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Alternative host | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Subscription Max Outstanding Messages | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum number of unprocessed messages (unacknowledged but not yet expired). If the value is negative, then there will be no limit on the number of unprocessed messages. Default is 1000.  |
+| Subscription Num Goroutines | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Number of goroutines created to read from the subscription. This does not limit the number of messages that can be processed concurrently or the maximum number of goroutines the input will create.  |
+| Tags | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
 

--- a/generated/google_cloud_storage.md
+++ b/generated/google_cloud_storage.md
@@ -10,159 +10,27 @@ Elasticsearch. This input is crucial for use cases like importing Stackdriver lo
 
 #### Configuration Parameters
 
-##### Bucket Timeout
-*Optional*
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Bucket Timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Defines the maximum time that the sdk will wait for a bucket api response before timing out. Valid time units are ns, us, ms, s, m, h.  |
+| Buckets | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | yaml | This attribute contains the details about a specific bucket like, name, number_of_workers, poll, poll_interval and bucket_timeout. The attribute 'name' is specific to a bucket as it describes the bucket name, while the fields number_of_workers, poll, poll_interval and bucket_timeout can exist both at the bucket level and at the global level. If you have already defined the attributes globally, then you can only specify the name in this yaml config. If you want to override any specific attribute for a specific bucket, then, you can define it here. Any attribute defined in the yaml will override the global definitions. Please see the relevant [Documentation](https://www.elastic.co/guide/en/beats/filebeat/8.5/filebeat-input-gcs.html#attrib-buckets) for further information.   |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Maximum number of workers | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | integer | Determines how many workers are spawned per bucket.  |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Polling | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Determines if the bucket will be continuously polled for new documents.  |
+| Polling interval | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Determines the time interval between polling operations.  |
+| Preserve original event | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Preserves a raw copy of the original event, added to the field `event.original`  |
+| Project ID | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | This attribute is required for various internal operations with respect to authentication, creating storage clients and logging which are used internally for various processing purposes.   |
+| Service Account File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | This attribute contains the service account credentials file, which can be generated from the google cloud console, ref [Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Required if a Service Account Key is not provided.   |
+| Service Account Key | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | This attribute contains the json service account credentials string, which can be generated from the google cloud console, ref[Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys). Required if a Service Account File is not provided.   |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
 
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: Defines the maximum time that the sdk will wait for a bucket api response before timing out. Valid time units are ns, us, ms, s, m, h.
-##### Buckets
-*Required*
-*type*: yaml
-
-*description*: This attribute contains the details about a specific bucket like, name, number_of_workers, poll, poll_interval and bucket_timeout. The attribute 'name' is specific to a bucket as it describes the bucket name, while the fields number_of_workers, poll, poll_interval and bucket_timeout can exist both at the bucket level and at the global level. If you have already defined the attributes globally, then you can only specify the name in this yaml config. If you want to override any specific attribute for a specific bucket, then, you can define it here. Any attribute defined in the yaml will override the global definitions. Please see the relevant [Documentation](https://www.elastic.co/guide/en/beats/filebeat/8.5/filebeat-input-gcs.html#attrib-buckets) for further information.
-
-##### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-##### Maximum number of workers
-*Optional*
-
-*type*: integer
-
-*description*: Determines how many workers are spawned per bucket.
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Polling
-*Optional*
-
-*type*: bool
-
-*description*: Determines if the bucket will be continuously polled for new documents.
-##### Polling interval
-*Optional*
-
-*type*: text
-
-*description*: Determines the time interval between polling operations.
-##### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`
-##### Project ID
-*Required*
-*type*: text
-
-*description*: This attribute is required for various internal operations with respect to authentication, creating storage clients and logging which are used internally for various processing purposes.
-
-##### Service Account File
-*Optional*
-
-*type*: text
-
-*description*: This attribute contains the service account credentials file, which can be generated from the google cloud console, ref [Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
-Required if a Service Account Key is not provided.
-
-##### Service Account Key
-*Optional*
-
-*type*: password
-
-*description*: This attribute contains the json service account credentials string, which can be generated from the google cloud console, ref[Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
-Required if a Service Account File is not provided.
-
-##### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-
-#### Advanced Parameters
-
-#### Bucket Timeout
-*Optional*
-
-*type*: text
-
-*description*: Defines the maximum time that the sdk will wait for a bucket api response before timing out. Valid time units are ns, us, ms, s, m, h.
-#### Buckets
-*Required*
-*type*: yaml
-
-*description*: This attribute contains the details about a specific bucket like, name, number_of_workers, poll, poll_interval and bucket_timeout. The attribute 'name' is specific to a bucket as it describes the bucket name, while the fields number_of_workers, poll, poll_interval and bucket_timeout can exist both at the bucket level and at the global level. If you have already defined the attributes globally, then you can only specify the name in this yaml config. If you want to override any specific attribute for a specific bucket, then, you can define it here. Any attribute defined in the yaml will override the global definitions. Please see the relevant [Documentation](https://www.elastic.co/guide/en/beats/filebeat/8.5/filebeat-input-gcs.html#attrib-buckets) for further information.
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Maximum number of workers
-*Optional*
-
-*type*: integer
-
-*description*: Determines how many workers are spawned per bucket.
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Polling
-*Optional*
-
-*type*: bool
-
-*description*: Determines if the bucket will be continuously polled for new documents.
-#### Polling interval
-*Optional*
-
-*type*: text
-
-*description*: Determines the time interval between polling operations.
-#### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`
-#### Project ID
-*Required*
-*type*: text
-
-*description*: This attribute is required for various internal operations with respect to authentication, creating storage clients and logging which are used internally for various processing purposes.
-
-#### Service Account File
-*Optional*
-
-*type*: text
-
-*description*: This attribute contains the service account credentials file, which can be generated from the google cloud console, ref [Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
-Required if a Service Account Key is not provided.
-
-#### Service Account Key
-*Optional*
-
-*type*: password
-
-*description*: This attribute contains the json service account credentials string, which can be generated from the google cloud console, ref[Service Account Keys](https://cloud.google.com/iam/docs/creating-managing-service-account-keys).
-Required if a Service Account File is not provided.
-
-#### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Alternative Host | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Used to override the default host for the storage client (default is storage.googleapis.com)  |
+| File Selectors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | If the GCS bucket will have events that correspond to files that this integration shouldn’t process, file_selectors can be used to limit the files that are downloaded. This is a list of selectors which is made up of regex patters. The regex should match the GCS bucket filepath. Regexes use [RE2 syntax](https://pkg.go.dev/regexp/syntax). Files that don’t match one of the regexes will not be processed.   |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Timestamp Epoch | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | integer | Defines the epoch time in seconds, which is used to filter out objects/files that are older than the specified timestamp.  |
 

--- a/generated/google_cloud_storage.md
+++ b/generated/google_cloud_storage.md
@@ -8,6 +8,7 @@ Elasticsearch. This input is crucial for use cases like importing Stackdriver lo
 
 ### Collecting logs from Custom GCS (Google Cloud Storage) Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/http_endpoint.md
+++ b/generated/http_endpoint.md
@@ -8,6 +8,7 @@ This input is commonly used for receiving webhooks from third-party applications
 
 ### Collecting logs from Custom HTTP Endpoint Logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/http_endpoint.md
+++ b/generated/http_endpoint.md
@@ -10,93 +10,37 @@ This input is commonly used for receiving webhooks from third-party applications
 
 #### Configuration Parameters
 
-##### Dataset name
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Listen Address | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind address for the HTTP listener. Use 0.0.0.0 to listen on all interfaces.   |
+| Listen port | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind port for the listener.   |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Preserve Original Event | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | This option copies the raw unmodified body of the incoming request to the event.original field as a string before sending the event to Elasticsearch.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
+| URL | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | This options specific which URL path to accept requests on. Defaults to /.  |
 
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+#### Advanced Configuration Parameters
 
-##### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the HTTP listener. Use 0.0.0.0 to listen on all interfaces.
-
-##### Listen port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Preserve Original Event
-*Optional*
-
-*type*: bool
-
-*description*: This option copies the raw unmodified body of the incoming request to the event.original field as a string before sending the event to Elasticsearch.
-##### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-##### URL
-*Optional*
-
-*type*: text
-
-*description*: This options specific which URL path to accept requests on. Defaults to /.
-
-#### Advanced Parameters
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the HTTP listener. Use 0.0.0.0 to listen on all interfaces.
-
-#### Listen port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Preserve Original Event
-*Optional*
-
-*type*: bool
-
-*description*: This option copies the raw unmodified body of the incoming request to the event.original field as a string before sending the event to Elasticsearch.
-#### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-#### URL
-*Optional*
-
-*type*: text
-
-*description*: This options specific which URL path to accept requests on. Defaults to /.
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Basic Auth | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Enables or disables HTTP basic auth for each incoming request. If enabled then username and password will also need to be configured.  |
+| Content Type | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | By default the input expects the incoming POST to include a Content-Type of application/json to try to enforce the incoming data to be valid JSON. In certain scenarios when the source of the request is not able to do that, it can be overwritten with another value or set to null.  |
+| Enable request tracing | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | The request tracer logs HTTP requests and responses to the agent's local file-system for debugging configurations. Enabling this request tracing compromises security and should only be used for debugging. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-cel.html#_resource_tracer_filename) for details.   |
+| HMAC Header | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The name of the header that contains the HMAC signature, for example X-Dropbox-Signature, X-Hub-Signature-256, etc. HMAC signatures may be encoded as hex or base64 (raw or standard).  |
+| HMAC Key | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The secret key used to calculate the HMAC signature. Typically, the webhook sender provides this value.  |
+| HMAC Prefix | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The prefix for the signature. Certain webhooks prefix the HMAC signature with a value, for example sha256=.  |
+| HMAC Type | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The hash algorithm to use for the HMAC comparison. At this time the only valid values are sha256 or sha1.  |
+| Include Headers | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | This options specifies a list of HTTP headers that should be copied from the incoming request and included in the document. All configured headers will always be canonicalized to match the headers of the incoming request. For example, ["content-type"] will become ["Content-Type"] when the filebeat is running.  |
+| HTTP Method | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | select | This options specifies which HTTP method to accept.  |
+| Password | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | If basic_auth is enabled, this is the password used for authentication against the HTTP listener. Requires username to also be set.  |
+| Prefix | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | This option specifies which prefix field the incoming request will be mapped to. Care should be taken when setting this option in conjunction with the Preserve Original Event or the Include Headers options. These will collide the `event` and `headers` fields respecetively, so avoid using a prefix that would result in data being placed in those fields if those other options are used. If a collision occurs the behavior is unspecified.  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| The CEL program to be run for each request. | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | textarea | Program is the CEL program that is executed each HTTP request to transform the request body data. More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-http_endpoint.html#_program).   |
+| Response Body | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The response body returned upon success. Should be a single line JSON string.  |
+| Response Code | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The HTTP response code returned upon success. Should be in the 2XX range.  |
+| Secret Header | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The header to check for a specific value specified by secret.value. Certain webhooks provide the possibility to include a special header and secret to identify the source.  |
+| Secret Value | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The secret stored in the header name specified by secret.header. Certain webhooks provide the possibility to include a special header and secret to identify the source.  |
+| TLS | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Options for enabling TLS for the listening webhook endpoint. See the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html) for a list of all options.  |
+| Username | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | If basic_auth is enabled, this is the username used for authentication against the HTTP listener. Requires password to also be set.  |
 

--- a/generated/jolokia.md
+++ b/generated/jolokia.md
@@ -8,6 +8,7 @@ for monitoring Java applications, providing insights into their performance and 
 
 ### Collecting logs from Jolokia Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/jolokia.md
+++ b/generated/jolokia.md
@@ -10,117 +10,29 @@ for monitoring Java applications, providing insights into their performance and 
 
 #### Configuration Parameters
 
-##### Hosts
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Hosts | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| HTTP Method | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| JMX Mappings | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | yaml |   |
+| Metrics Path | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Period | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| SSL CA Trusted Fingerprint | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.  |
+| SSL Certificate | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | SSL certificate. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.  |
+| SSL Certificate Authorities | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.  |
+| SSL Private Key | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | SSL private key. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.  |
+| SSL Key Passphrase | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | SSL key passphrase. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.  |
 
-*description*: 
-##### HTTP Method
-*Required*
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: 
-##### JMX Mappings
-*Required*
-*type*: yaml
-
-*description*: 
-##### Metrics Path
-*Required*
-*type*: text
-
-*description*: 
-##### Period
-*Required*
-*type*: text
-
-*description*: 
-##### SSL CA Trusted Fingerprint
-*Optional*
-
-*type*: text
-
-*description*: SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-##### SSL Certificate
-*Optional*
-
-*type*: text
-
-*description*: SSL certificate. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-##### SSL Certificate Authorities
-*Optional*
-
-*type*: text
-
-*description*: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-##### SSL Private Key
-*Optional*
-
-*type*: text
-
-*description*: SSL private key. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-##### SSL Key Passphrase
-*Optional*
-
-*type*: password
-
-*description*: SSL key passphrase. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-
-#### Advanced Parameters
-
-#### Hosts
-*Required*
-*type*: text
-
-*description*: 
-#### HTTP Method
-*Required*
-*type*: text
-
-*description*: 
-#### JMX Mappings
-*Required*
-*type*: yaml
-
-*description*: 
-#### Metrics Path
-*Required*
-*type*: text
-
-*description*: 
-#### Period
-*Required*
-*type*: text
-
-*description*: 
-#### SSL CA Trusted Fingerprint
-*Optional*
-
-*type*: text
-
-*description*: SSL CA trusted fingerprint. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-#### SSL Certificate
-*Optional*
-
-*type*: text
-
-*description*: SSL certificate. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-#### SSL Certificate Authorities
-*Optional*
-
-*type*: text
-
-*description*: SSL certificate authorities.  See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-#### SSL Private Key
-*Optional*
-
-*type*: text
-
-*description*: SSL private key. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
-#### SSL Key Passphrase
-*Optional*
-
-*type*: password
-
-*description*: SSL key passphrase. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| HTTP config options: bearer_token_file | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | If defined, the contents of the file will be read once at initialization and then the value will be used in an HTTP Authorization header.  |
+| HTTP config options: connect_timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Total time limit for an HTTP connection to be completed (Default 2 seconds)  |
+| HTTP config options: headers | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | A list of headers to use with the HTTP request  |
+| HTTP config options: Password | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The password to use for basic authentication.  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.   |
+| SSL Verification Mode | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | SSL verification mode. See [documentation](https://www.elastic.co/guide/en/fleet/current/elastic-agent-ssl-configuration.html) for details.  |
+| HTTP config options: timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Total time limit for HTTP requests made by the module (Default 10 seconds)  |
+| HTTP config options: Username | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The username to use for basic authentication.  |
 

--- a/generated/journald.md
+++ b/generated/journald.md
@@ -10,33 +10,16 @@ structured log data and associated metadata. It helps integrate system-level log
 
 #### Configuration Parameters
 
-##### Condition
-*Optional*
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Condition | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Condition to filter when to run this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.  |
+| Include Matches | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | A list of filter expressions used to select the logs to read (e.g. `_SYSTEMD_UNIT=vault.service`). Defaults to all logs. See [include_matches](https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-input-journald.html#filebeat-input-journald-include-matches) for details.   |
 
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: Condition to filter when to run this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
-##### Include Matches
-*Optional*
-
-*type*: text
-
-*description*: A list of filter expressions used to select the logs to read (e.g. `_SYSTEMD_UNIT=vault.service`). Defaults to all logs. See [include_matches](https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-input-journald.html#filebeat-input-journald-include-matches) for details.
-
-
-#### Advanced Parameters
-
-#### Condition
-*Optional*
-
-*type*: text
-
-*description*: Condition to filter when to run this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
-#### Include Matches
-*Optional*
-
-*type*: text
-
-*description*: A list of filter expressions used to select the logs to read (e.g. `_SYSTEMD_UNIT=vault.service`). Defaults to all logs. See [include_matches](https://www.elastic.co/guide/en/beats/filebeat/7.x/filebeat-input-journald.html#filebeat-input-journald-include-matches) for details.
-
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Journal paths | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | List of journals to read from. Defaults to the system journal.   |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata.  This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Tags | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Tags to include in the published event.   |
 

--- a/generated/journald.md
+++ b/generated/journald.md
@@ -8,6 +8,7 @@ structured log data and associated metadata. It helps integrate system-level log
 
 ### Collecting logs from Custom Journald logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/log.md
+++ b/generated/log.md
@@ -8,6 +8,7 @@ and forwarding them to Elasticsearch or other destinations. This input is essent
 
 ### Collecting logs from Custom Logs (Deprecated)
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/log.md
+++ b/generated/log.md
@@ -10,7 +10,18 @@ and forwarding them to Elasticsearch or other destinations. This input is essent
 
 #### Configuration Parameters
 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
 
-#### Advanced Parameters
+#### Advanced Configuration Parameters
 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Custom configurations | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Additional settings to be added to the configuration. Be careful using this as it might break the input as those settings are not validated and can override the settings specified above. See [`log` input settings docs](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-log.html) for details.   |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Set the name for your dataset. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Exclude files | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Patterns to be ignored  |
+| Ignore events older than | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | If this option is specified, events that are older than the specified amount of time are ignored. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".  |
+| Log file path | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Path to log files to be collected  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
 

--- a/generated/prometheus_input.md
+++ b/generated/prometheus_input.md
@@ -8,6 +8,7 @@ instrumented for Prometheus. It's a crucial component for unifying Prometheus-co
 
 ### Collecting logs from Prometheus Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/prometheus_input.md
+++ b/generated/prometheus_input.md
@@ -10,103 +10,24 @@ instrumented for Prometheus. It's a crucial component for unifying Prometheus-co
 
 #### Configuration Parameters
 
-##### Condition
-*Optional*
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Condition | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.  |
+| Datastream Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Name of Datastream dataset  |
+| Hosts | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Leader Election | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Enable leaderelection between a set of Elastic Agents running on Kubernetes. See [Kubernetes LeaderElection Provider](https://www.elastic.co/guide/en/fleet/current/kubernetes_leaderelection-provider.html) for details.  |
+| Password | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password |   |
+| Period | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Rate Counters | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool |   |
+| Use Types | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool |   |
+| Username | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
 
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
-##### Datastream Dataset name
-*Required*
-*type*: text
-
-*description*: Name of Datastream dataset
-##### Hosts
-*Required*
-*type*: text
-
-*description*: 
-##### Leader Election
-*Required*
-*type*: bool
-
-*description*: Enable leaderelection between a set of Elastic Agents running on Kubernetes. See [Kubernetes LeaderElection Provider](https://www.elastic.co/guide/en/fleet/current/kubernetes_leaderelection-provider.html) for details.
-##### Password
-*Optional*
-
-*type*: password
-
-*description*: 
-##### Period
-*Required*
-*type*: text
-
-*description*: 
-##### Rate Counters
-*Required*
-*type*: bool
-
-*description*: 
-##### Use Types
-*Required*
-*type*: bool
-
-*description*: 
-##### Username
-*Optional*
-
-*type*: text
-
-*description*: 
-
-#### Advanced Parameters
-
-#### Condition
-*Optional*
-
-*type*: text
-
-*description*: Condition to filter when to collect this input. See [Dynamic Input Configuration](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html) for details.
-#### Datastream Dataset name
-*Required*
-*type*: text
-
-*description*: Name of Datastream dataset
-#### Hosts
-*Required*
-*type*: text
-
-*description*: 
-#### Leader Election
-*Required*
-*type*: bool
-
-*description*: Enable leaderelection between a set of Elastic Agents running on Kubernetes. See [Kubernetes LeaderElection Provider](https://www.elastic.co/guide/en/fleet/current/kubernetes_leaderelection-provider.html) for details.
-#### Password
-*Optional*
-
-*type*: password
-
-*description*: 
-#### Period
-*Required*
-*type*: text
-
-*description*: 
-#### Rate Counters
-*Required*
-*type*: bool
-
-*description*: 
-#### Use Types
-*Required*
-*type*: bool
-
-*description*: 
-#### Username
-*Optional*
-
-*type*: text
-
-*description*: 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Metrics Filters Exclude | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| Metrics Filters Include | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.     |
+| SSL Certificate Authorities | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | SSL Certificate Authorities. See [documentation](https://www.elastic.co/guide/en/beats/metricbeat/current/configuration-ssl.html#client-certificate-authorities) for details.  |
 

--- a/generated/sql.md
+++ b/generated/sql.md
@@ -8,6 +8,7 @@ input is highly flexible, supporting multiple database drivers (e.g., MySQL, Pos
 
 ### Collecting logs from SQL Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/sql.md
+++ b/generated/sql.md
@@ -10,37 +10,19 @@ input is highly flexible, supporting multiple database drivers (e.g., MySQL, Pos
 
 #### Configuration Parameters
 
-##### Driver
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Driver | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text |   |
+| Hosts | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | password |   |
+| SQL Queries | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | yaml |   |
 
-*description*: 
-##### Hosts
-*Required*
-*type*: password
+#### Advanced Configuration Parameters
 
-*description*: 
-##### SQL Queries
-*Required*
-*type*: yaml
-
-*description*: 
-
-#### Advanced Parameters
-
-#### Driver
-*Required*
-*type*: text
-
-*description*: 
-#### Hosts
-*Required*
-*type*: password
-
-*description*: 
-#### SQL Queries
-*Required*
-*type*: yaml
-
-*description*: 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Condition | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Condition to filter when to apply this datastream. Refer to [Conditions](https://www.elastic.co/guide/en/fleet/current/dynamic-input-configuration.html#conditions) on how to use the available keys in conditions.  |
+| Merge Results | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Merge results from multiple queries to a single event (restrictions apply)  |
+| Period | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the events are shipped. See [Processors](https://www.elastic.co/guide/en/fleet/current/elastic-agent-processor-configuration.html) for details.  |
+| SSL Configuration | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | SSL configuration options. See [documentation](https://www.elastic.co/docs/reference/integrations/sql) for details.  |
 

--- a/generated/statsd_input.md
+++ b/generated/statsd_input.md
@@ -8,6 +8,7 @@ services. It's a key component for gathering custom performance data and integra
 
 ### Collecting logs from StatsD Input
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/statsd_input.md
+++ b/generated/statsd_input.md
@@ -10,31 +10,13 @@ services. It's a key component for gathering custom performance data and integra
 
 #### Configuration Parameters
 
-##### Listen Address
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Listen Address | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.   |
+| Listen Port | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind port for the listener.   |
 
-*description*: Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
+#### Advanced Configuration Parameters
 
-##### Listen Port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-
-#### Advanced Parameters
-
-#### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
-
-#### Listen Port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
 

--- a/generated/tcp.md
+++ b/generated/tcp.md
@@ -10,91 +10,28 @@ events, or other structured data from applications and devices that communicate 
 
 #### Configuration Parameters
 
-##### Dataset name
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Listen Address | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.   |
+| Listen port | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind port for the listener.   |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Preserve original event | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Preserves a raw copy of the original event, added to the field `event.original`.  |
+| Syslog Parsing | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Enable the syslog parser to automatically parse RFC3164 and RFC5424 syslog formatted data. The syslog parser can be configured under Advanced Options.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
 
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+#### Advanced Configuration Parameters
 
-##### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
-
-##### Listen port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`.
-##### Syslog Parsing
-*Optional*
-
-*type*: bool
-
-*description*: Enable the syslog parser to automatically parse RFC3164 and RFC5424 syslog formatted data. The syslog parser can be configured under Advanced Options.
-##### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-
-#### Advanced Parameters
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
-
-#### Listen port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`.
-#### Syslog Parsing
-*Optional*
-
-*type*: bool
-
-*description*: Enable the syslog parser to automatically parse RFC3164 and RFC5424 syslog formatted data. The syslog parser can be configured under Advanced Options.
-#### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Custom configurations | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Here YAML configuration options can be used to be added to your configuration. Be careful using this as it might break your configuration file.   |
+| Framing | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Specify the framing used to split incoming events. Can be one of delimiter or rfc6587. The default is delimiter  |
+| Keep Null Values | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | If this option is set to true, fields with null values will be published in the output document. By default, keep_null is set to false.  |
+| Line Delimiter | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Specify the characters used to split the incoming events. The default is \n.  |
+| Max Connections | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The at most number of connections to accept at any given point in time.  |
+| Max Message Size | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum size of the message received over TCP. The default is 20MiB  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| SSL Configuration | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | SSL configuration options. See [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config) for details.  |
+| Syslog Configuration | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | i.e. field, format, time zone, etc. See [Syslog](https://www.elastic.co/guide/en/beats/filebeat/current/syslog.html) for details.  |
+| Timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The duration of inactivity before a remote connection is closed. The default is 300s. Valid time units are ns, us, ms, s, m, h.  |
 

--- a/generated/tcp.md
+++ b/generated/tcp.md
@@ -8,6 +8,9 @@ events, or other structured data from applications and devices that communicate 
 
 ### Collecting logs from Custom TCP Logs
 
+To collect logs with the `tcp` input, configure the Listen Address and Listen Port. When deployed with Elastic Agent, the agent will listen for TCP messages on the configured address and port.
+If a secure TCP connection is used, you may need to specify the SSL details in the `SSL` parameter.
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/udp.md
+++ b/generated/udp.md
@@ -10,91 +10,25 @@ transmit data via the unreliable but fast UDP protocol, such as syslog messages 
 
 #### Configuration Parameters
 
-##### Dataset name
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Listen Address | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.   |
+| Listen Port | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Bind port for the listener.   |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Preserve original event | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Preserves a raw copy of the original event, added to the field `event.original`.  |
+| Syslog Parsing | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Enable the syslog parser to automatically parse RFC3164 and RFC5424 syslog formatted data. The syslog parser can be configured under Advanced Options.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
 
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
+#### Advanced Configuration Parameters
 
-##### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
-
-##### Listen Port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`.
-##### Syslog Parsing
-*Optional*
-
-*type*: bool
-
-*description*: Enable the syslog parser to automatically parse RFC3164 and RFC5424 syslog formatted data. The syslog parser can be configured under Advanced Options.
-##### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
-
-#### Advanced Parameters
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Listen Address
-*Required*
-*type*: text
-
-*description*: Bind address for the listener. Use 0.0.0.0 to listen on all interfaces.
-
-#### Listen Port
-*Required*
-*type*: text
-
-*description*: Bind port for the listener.
-
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original event, added to the field `event.original`.
-#### Syslog Parsing
-*Optional*
-
-*type*: bool
-
-*description*: Enable the syslog parser to automatically parse RFC3164 and RFC5424 syslog formatted data. The syslog parser can be configured under Advanced Options.
-#### Tags
-*Optional*
-
-*type*: text
-
-*description*: Tags to include in the published event
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Custom configurations | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Here YAML configuration options can be used to be added to your configuration. Be careful using this as it might break your configuration file.   |
+| Keep Null Values | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | If this option is set to true, fields with null values will be published in the output document. By default, keep_null is set to false.  |
+| Max Message Size | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum size of the message received over UDP. The default is 10KiB  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.   |
+| Read Buffer Size | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The size of the read buffer on the UDP socket in the format KiB/MiB, an example would be: 10KiB   |
+| Syslog Options | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | i.e. format, time zone, etc.  |
+| Timeout | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The read and write timeout for socket operations. Valid time units are ns, us, ms, s, m, h.  |
 

--- a/generated/udp.md
+++ b/generated/udp.md
@@ -8,6 +8,7 @@ transmit data via the unreliable but fast UDP protocol, such as syslog messages 
 
 ### Collecting logs from Custom UDP Logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/unifiedlogs.md
+++ b/generated/unifiedlogs.md
@@ -8,6 +8,7 @@ in memory and on disk. This input allows Filebeat to stream these structured eve
 
 ### Collecting logs from Custom macOS Unified Logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/unifiedlogs.md
+++ b/generated/unifiedlogs.md
@@ -10,207 +10,28 @@ in memory and on disk. This input allows Filebeat to stream these structured eve
 
 #### Configuration Parameters
 
-##### Must backfill
-*Optional*
-
-*type*: bool
-
-*description*: If set to true the input will process all available logs since the beginning
-of time the first time it starts.
-
-##### Include backtrace
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable backtrace level messages.
-
-##### Include debug
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable debug level messages.
-
-##### End date
-*Optional*
-
-*type*: text
-
-*description*: Shows content up to the provided date.
-The following date/time formats are accepted:
-`YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DD HH:MM:SSZZZZZ`.
-
-##### Include info
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable info level messages.
-
-##### Use mach continuous time
-*Optional*
-
-*type*: bool
-
-*description*: Use mach continuous time timestamps rather than walltime.
-
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Predicate
-*Optional*
-
-*type*: text
-
-*description*: Filters messages using the provided predicate based on NSPredicate.
-A compound predicate or multiple predicates can be provided as a list.
-
-For detailed information on the use of predicate based filtering,
-please refer to the https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html[Predicate Programming Guide].
-
-##### Process
-*Optional*
-
-*type*: text
-
-*description*: A list of the processes on which to operate. It accepts a PID or process name.
-
-##### Include signpost
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable signpost level messages.
-
-##### Include source
-*Optional*
-
-*type*: bool
-
-*description*: Include symbol names and source line numbers for messages, if available.
-
-##### Start date
-*Optional*
-
-*type*: text
-
-*description*: Shows content starting from the provided date.
-The following date/time formats are accepted:
-`YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DD HH:MM:SSZZZZZ`.
-
-##### Annotate unreliable
-*Optional*
-
-*type*: bool
-
-*description*: Annotate events with whether the log was emitted unreliably.
-
-
-#### Advanced Parameters
-
-#### Must backfill
-*Optional*
-
-*type*: bool
-
-*description*: If set to true the input will process all available logs since the beginning
-of time the first time it starts.
-
-#### Include backtrace
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable backtrace level messages.
-
-#### Include debug
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable debug level messages.
-
-#### End date
-*Optional*
-
-*type*: text
-
-*description*: Shows content up to the provided date.
-The following date/time formats are accepted:
-`YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DD HH:MM:SSZZZZZ`.
-
-#### Include info
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable info level messages.
-
-#### Use mach continuous time
-*Optional*
-
-*type*: bool
-
-*description*: Use mach continuous time timestamps rather than walltime.
-
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Predicate
-*Optional*
-
-*type*: text
-
-*description*: Filters messages using the provided predicate based on NSPredicate.
-A compound predicate or multiple predicates can be provided as a list.
-
-For detailed information on the use of predicate based filtering,
-please refer to the https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html[Predicate Programming Guide].
-
-#### Process
-*Optional*
-
-*type*: text
-
-*description*: A list of the processes on which to operate. It accepts a PID or process name.
-
-#### Include signpost
-*Optional*
-
-*type*: bool
-
-*description*: Disable or enable signpost level messages.
-
-#### Include source
-*Optional*
-
-*type*: bool
-
-*description*: Include symbol names and source line numbers for messages, if available.
-
-#### Start date
-*Optional*
-
-*type*: text
-
-*description*: Shows content starting from the provided date.
-The following date/time formats are accepted:
-`YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DD HH:MM:SSZZZZZ`.
-
-#### Annotate unreliable
-*Optional*
-
-*type*: bool
-
-*description*: Annotate events with whether the log was emitted unreliably.
-
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Must backfill | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | If set to true the input will process all available logs since the beginning of time the first time it starts.   |
+| Include backtrace | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Disable or enable backtrace level messages.   |
+| Include debug | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Disable or enable debug level messages.   |
+| End date | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Shows content up to the provided date. The following date/time formats are accepted: `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DD HH:MM:SSZZZZZ`.   |
+| Include info | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Disable or enable info level messages.   |
+| Use mach continuous time | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Use mach continuous time timestamps rather than walltime.   |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Predicate | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Filters messages using the provided predicate based on NSPredicate. A compound predicate or multiple predicates can be provided as a list.  For detailed information on the use of predicate based filtering, please refer to the https://developer.apple.com/library/mac/documentation/Cocoa/Conceptual/Predicates/Articles/pSyntax.html[Predicate Programming Guide].   |
+| Process | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | A list of the processes on which to operate. It accepts a PID or process name.   |
+| Include signpost | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Disable or enable signpost level messages.   |
+| Include source | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Include symbol names and source line numbers for messages, if available.   |
+| Start date | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Shows content starting from the provided date. The following date/time formats are accepted: `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS`, `YYYY-MM-DD HH:MM:SSZZZZZ`.   |
+| Annotate unreliable | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | Annotate events with whether the log was emitted unreliably.   |
+
+#### Advanced Configuration Parameters
+
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Archive file | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Display events stored in the given archive. The archive must be a valid log archive bundle with the suffix `.logarchive`.   |
+| Custom Configurations | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | YAML configuration options for the input. Be careful, this may break the integration.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
+| Trace file | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Display events stored in the given `.tracev3` file. In order to be decoded, the file must be contained within a valid `.logarchive`   |
 

--- a/generated/websocket.md
+++ b/generated/websocket.md
@@ -8,6 +8,7 @@ low-latency, full-duplex communication, making it ideal for streaming data like 
 
 ### Collecting logs from Custom Websocket logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/websocket.md
+++ b/generated/websocket.md
@@ -10,211 +10,31 @@ low-latency, full-duplex communication, making it ideal for streaming data like 
 
 #### Configuration Parameters
 
-##### Basic Auth Token
-*Optional*
-
-*type*: password
-
-*description*: The token to be used for Basic Authentication.
-##### Bearer Auth Token
-*Optional*
-
-*type*: password
-
-*description*: The token to be used for Bearer Authentication.
-##### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-##### Delete redacted fields
-*Required*
-*type*: bool
-
-*description*: The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will
-leak information, the fields can be deleted from logging by setting this configuration to true.
-
-##### Custom Header Key
-*Optional*
-
-*type*: text
-
-*description*: The custom header key name for Authentication.
-##### Custom Header Value
-*Optional*
-
-*type*: password
-
-*description*: The custom header key value for Authentication.
-##### Maximum Reconnect Attempts
-*Optional*
-
-*type*: integer
-
-*description*: The maximum number of times the agent will attempt to reconnect to the websocket endpoint if the connection is lost before giving up.
-##### Maximum Wait Time
-*Optional*
-
-*type*: text
-
-*description*: The maximum amount of time the agent will wait before attempting to reconnect to the websocket endpoint if the connection is lost. 
-This is a time duration value. Examples, 1s, 1m, 1h.
-
-##### Minimum Wait Time
-*Optional*
-
-*type*: text
-
-*description*: The minimum amount of time the agent will wait before attempting to reconnect to the websocket endpoint if the connection is lost. 
-This is a time duration value. Examples, 1s, 1m, 1h.
-
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### The CEL program to be run for each message.
-*Required*
-*type*: textarea
-
-*description*: Program is the The CEL program that is executed on each message received.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#_execution_2).
-
-##### Redacted fields
-*Optional*
-
-*type*: text
-
-*description*: Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included
-in logs. This may leak secrets, so list sensitive state fields in this configuration.
-
-##### Defined Regular Expressions
-*Optional*
-
-*type*: yaml
-
-*description*: Regexps is the set of regular expression to be made available to the program by name. The syntax used is [RE2](https://github.com/google/re2/wiki/Syntax).
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#regexp-websocket).
-
-##### Initial CEL evaluation state
-*Optional*
-
-*type*: yaml
-
-*description*: State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#state-websocket).
-
-##### URL
-*Required*
-*type*: text
-
-*description*: URL of the Websocket Server.
-
-#### Advanced Parameters
-
-#### Basic Auth Token
-*Optional*
-
-*type*: password
-
-*description*: The token to be used for Basic Authentication.
-#### Bearer Auth Token
-*Optional*
-
-*type*: password
-
-*description*: The token to be used for Bearer Authentication.
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-
-#### Delete redacted fields
-*Required*
-*type*: bool
-
-*description*: The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will
-leak information, the fields can be deleted from logging by setting this configuration to true.
-
-#### Custom Header Key
-*Optional*
-
-*type*: text
-
-*description*: The custom header key name for Authentication.
-#### Custom Header Value
-*Optional*
-
-*type*: password
-
-*description*: The custom header key value for Authentication.
-#### Maximum Reconnect Attempts
-*Optional*
-
-*type*: integer
-
-*description*: The maximum number of times the agent will attempt to reconnect to the websocket endpoint if the connection is lost before giving up.
-#### Maximum Wait Time
-*Optional*
-
-*type*: text
-
-*description*: The maximum amount of time the agent will wait before attempting to reconnect to the websocket endpoint if the connection is lost. 
-This is a time duration value. Examples, 1s, 1m, 1h.
-
-#### Minimum Wait Time
-*Optional*
-
-*type*: text
-
-*description*: The minimum amount of time the agent will wait before attempting to reconnect to the websocket endpoint if the connection is lost. 
-This is a time duration value. Examples, 1s, 1m, 1h.
-
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### The CEL program to be run for each message.
-*Required*
-*type*: textarea
-
-*description*: Program is the The CEL program that is executed on each message received.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#_execution_2).
-
-#### Redacted fields
-*Optional*
-
-*type*: text
-
-*description*: Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included
-in logs. This may leak secrets, so list sensitive state fields in this configuration.
-
-#### Defined Regular Expressions
-*Optional*
-
-*type*: yaml
-
-*description*: Regexps is the set of regular expression to be made available to the program by name. The syntax used is [RE2](https://github.com/google/re2/wiki/Syntax).
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#regexp-websocket).
-
-#### Initial CEL evaluation state
-*Optional*
-
-*type*: yaml
-
-*description*: State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists.
-More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#state-websocket).
-
-#### URL
-*Required*
-*type*: text
-
-*description*: URL of the Websocket Server.
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Basic Auth Token | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The token to be used for Basic Authentication.  |
+| Bearer Auth Token | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The token to be used for Bearer Authentication.  |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).   |
+| Delete redacted fields | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | The default behavior for field redaction is to replace characters with `*`s. If field value length or presence will leak information, the fields can be deleted from logging by setting this configuration to true.   |
+| Custom Header Key | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The custom header key name for Authentication.  |
+| Custom Header Value | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | password | The custom header key value for Authentication.  |
+| Maximum Reconnect Attempts | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | integer | The maximum number of times the agent will attempt to reconnect to the websocket endpoint if the connection is lost before giving up.  |
+| Maximum Wait Time | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The maximum amount of time the agent will wait before attempting to reconnect to the websocket endpoint if the connection is lost.  This is a time duration value. Examples, 1s, 1m, 1h.   |
+| Minimum Wait Time | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The minimum amount of time the agent will wait before attempting to reconnect to the websocket endpoint if the connection is lost.  This is a time duration value. Examples, 1s, 1m, 1h.   |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| The CEL program to be run for each message. | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | textarea | Program is the The CEL program that is executed on each message received. More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#_execution_2).   |
+| Redacted fields | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Fields to redact in debug logs. When logging at debug-level the input state and CEL evaluation state are included in logs. This may leak secrets, so list sensitive state fields in this configuration.   |
+| Defined Regular Expressions | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Regexps is the set of regular expression to be made available to the program by name. The syntax used is [RE2](https://github.com/google/re2/wiki/Syntax). More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#regexp-websocket).   |
+| Initial CEL evaluation state | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | State is the initial state to be provided to the program. If it has a cursor field, that field will be overwritten by any stored cursor, but will be available if no stored cursor exists. More information can be found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/filebeat-input-websocket.html#state-websocket).   |
+| URL | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | URL of the Websocket Server.  |
+
+#### Advanced Configuration Parameters
+
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Blanket Retries | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | If enabled the agent will retry connection attempts irrespective of the type of connection/network error.  |
+| Infinite Retries | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | bool | If enabled the agent will retry connection attempts indefinitely irrespective of the "Maximum Reconnect Attempts" value.  |
+| Processors | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Processors are used to reduce the number of fields in the exported event or to enhance the event with metadata. This executes in the agent before the logs are parsed. See [Processors](https://www.elastic.co/guide/en/beats/filebeat/current/filtering-and-enhancing-data.html) for details.  |
+| SSL Configuration | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | i.e. certificate_authorities, supported_protocols, verification_mode etc, more examples found in the [documentation](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-ssl.html#ssl-common-config).  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text |   |
 

--- a/generated/windows_etw.md
+++ b/generated/windows_etw.md
@@ -10,103 +10,23 @@ application activity. The input supports various ETW providers and can operate i
 
 #### Configuration Parameters
 
-##### Dataset name
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).  |
+| File | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Path to an .etl file to read from.  |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Provider GUID | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | GUID of of an ETW provider (eg. `{EB79061A-A566-4698-9119-3ED2807060E7}`). Run `logman query providers` to list the available providers in the endpoint.  |
+| Provider Name | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Name of of an ETW provider (eg. Microsoft-Windows-DNSServer). Run `logman query providers` to list the available providers in the endpoint.  |
+| Session | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | An existing ETW session to read from. Existing sessions can be listed using `logman query -ets`.  |
+| Session Name | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | When specifying a provider, a new session is created. This controls the name for the new ETW session it will create. If not specified, the session will be named using the provider ID prefixed by 'Elastic-'.  |
+| Trace Level | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Defines the filtering level for events based on severity. Valid options include critical, error, warning, information, and verbose. The provider writes an event if the event's level is more severe or equal to the defined value.  |
 
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-##### File
-*Optional*
+#### Advanced Configuration Parameters
 
-*type*: text
-
-*description*: Path to an .etl file to read from.
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Provider GUID
-*Optional*
-
-*type*: text
-
-*description*: GUID of of an ETW provider (eg. `{EB79061A-A566-4698-9119-3ED2807060E7}`). Run `logman query providers` to list the available providers in the endpoint.
-##### Provider Name
-*Optional*
-
-*type*: text
-
-*description*: Name of of an ETW provider (eg. Microsoft-Windows-DNSServer). Run `logman query providers` to list the available providers in the endpoint.
-##### Session
-*Optional*
-
-*type*: text
-
-*description*: An existing ETW session to read from. Existing sessions can be listed using `logman query -ets`.
-##### Session Name
-*Optional*
-
-*type*: text
-
-*description*: When specifying a provider, a new session is created. This controls the name for the new ETW session it will create. If not specified, the session will be named using the provider ID prefixed by 'Elastic-'.
-##### Trace Level
-*Optional*
-
-*type*: text
-
-*description*: Defines the filtering level for events based on severity. Valid options include critical, error, warning, information, and verbose. The provider writes an event if the event's level is more severe or equal to the defined value.
-
-#### Advanced Parameters
-
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-#### File
-*Optional*
-
-*type*: text
-
-*description*: Path to an .etl file to read from.
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Provider GUID
-*Optional*
-
-*type*: text
-
-*description*: GUID of of an ETW provider (eg. `{EB79061A-A566-4698-9119-3ED2807060E7}`). Run `logman query providers` to list the available providers in the endpoint.
-#### Provider Name
-*Optional*
-
-*type*: text
-
-*description*: Name of of an ETW provider (eg. Microsoft-Windows-DNSServer). Run `logman query providers` to list the available providers in the endpoint.
-#### Session
-*Optional*
-
-*type*: text
-
-*description*: An existing ETW session to read from. Existing sessions can be listed using `logman query -ets`.
-#### Session Name
-*Optional*
-
-*type*: text
-
-*description*: When specifying a provider, a new session is created. This controls the name for the new ETW session it will create. If not specified, the session will be named using the provider ID prefixed by 'Elastic-'.
-#### Trace Level
-*Optional*
-
-*type*: text
-
-*description*: Defines the filtering level for events based on severity. Valid options include critical, error, warning, information, and verbose. The provider writes an event if the event's level is more severe or equal to the defined value.
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Custom Configurations | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | Here YAML configuration options can be used to be added to your configuration. Be careful using this as it might break your configuration file.  |
+| Match All Keyword | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Similar to MatchAnyKeyword, this 8-byte bitmask filters events that match all specified keyword bits. Default value is 0 to let every event pass. Run `logman query providers "<provider.name>"` to list the available keywords for a specific provider.  |
+| Match Any Keyword | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | An 8-byte bitmask used for filtering events from specific provider subcomponents based on keyword matching. Any matching keyword will enable the event to be written. Default value is `0xfffffffffffffffff` so it matches every available keyword. Run `logman query providers "<provider.name>"` to list the available keywords for a specific provider.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event.  |
 

--- a/generated/windows_etw.md
+++ b/generated/windows_etw.md
@@ -8,6 +8,7 @@ application activity. The input supports various ETW providers and can operate i
 
 ### Collecting logs from Custom Windows ETW logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/generated/winlog.md
+++ b/generated/winlog.md
@@ -10,51 +10,23 @@ for monitoring Windows systems, providing essential data for security analysis, 
 
 #### Configuration Parameters
 
-##### Channel Name
-*Required*
-*type*: text
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Channel Name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Name of Windows event log channel (eg. Microsoft-Windows-PowerShell/Operational). It expects a single channel name. To collect multiple channels, add multiple integrations.  |
+| Dataset name | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | text | Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).  |
+| Ingest Pipeline | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The Ingest Node pipeline ID to be used by the integration.   |
+| Preserve original event | ![Required](https://img.shields.io/badge/✔-93c93e?style=flat) | bool | Preserves a raw copy of the original XML event, added to the field `event.original`  |
 
-*description*: Name of Windows event log channel (eg. Microsoft-Windows-PowerShell/Operational). It expects a single channel name. To collect multiple channels, add multiple integrations.
-##### Dataset name
-*Required*
-*type*: text
+#### Advanced Configuration Parameters
 
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-##### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-##### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original XML event, added to the field `event.original`
-
-#### Advanced Parameters
-
-#### Channel Name
-*Required*
-*type*: text
-
-*description*: Name of Windows event log channel (eg. Microsoft-Windows-PowerShell/Operational). It expects a single channel name. To collect multiple channels, add multiple integrations.
-#### Dataset name
-*Required*
-*type*: text
-
-*description*: Dataset to write data to. Changing the dataset will send the data to a different index. You can't use `-` in the name of a dataset and only valid characters for [Elasticsearch index names](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html).
-#### Ingest Pipeline
-*Optional*
-
-*type*: text
-
-*description*: The Ingest Node pipeline ID to be used by the integration.
-
-#### Preserve original event
-*Required*
-*type*: bool
-
-*description*: Preserves a raw copy of the original XML event, added to the field `event.original`
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
+| Custom Configurations | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | yaml | YAML configuration options for winlog input. Be careful, this may break the integration.  |
+| Event ID | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | A list of included and excluded (blocked) event IDs. The value is a comma-separated list.  The accepted values are single event IDs to include (e.g. 4624), a range of event IDs to include (e.g. 4700-4800),  and single event IDs to exclude (e.g. -4735).  Limit 22 clauses, lower in some situations. See integration documentation for more details.  |
+| Ignore events older than | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | If this option is specified, events that are older than the specified amount of time are ignored. Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".  |
+| Language ID | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | The language ID the events will be rendered in. The language will be forced regardless of the system language. A complete list of language IDs can be found [here](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c). It defaults to `0`, which indicates to use the system language. E.g.: `0x0409` for `en-US`  |
+| Level | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | A list of event levels to include. The value is a comma-separated list of levels. Accepted levels are: `critical`, `error`, `warning`, `information`, and `verbose`.  |
+| Providers | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | A list of providers (source names) to include.  |
+| Tags | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Tags to include in the published event  |
+| XML Query | ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat) | text | Provide a custom XML query. This option is mutually exclusive with the `name`, `event_id`, `ignore_older`, `level`, and `providers` options. These options should be included in the XML query directly. Furthermore, an id must be provided. Custom XML queries provide more flexibility and advanced options than the simpler query options.  |
 

--- a/generated/winlog.md
+++ b/generated/winlog.md
@@ -8,6 +8,7 @@ for monitoring Windows systems, providing essential data for security analysis, 
 
 ### Collecting logs from Custom Windows Event Logs
 
+
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |

--- a/http-endpoint.md
+++ b/http-endpoint.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Http Endpoint

--- a/httpjson.md
+++ b/httpjson.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Http Json

--- a/journald.md
+++ b/journald.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Journald

--- a/kafka.md
+++ b/kafka.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Kafka

--- a/logfile.md
+++ b/logfile.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Logfile

--- a/netflow.md
+++ b/netflow.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Netflow

--- a/o365audit.md
+++ b/o365audit.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from o365audit

--- a/redis.md
+++ b/redis.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Redis

--- a/salesforce.md
+++ b/salesforce.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Salesforce

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -1,8 +1,7 @@
 from functools import wraps
-import jinja2
 import os
 from os import path
-from pathlib import Path
+import jinja2
 import yaml
 
 def generate_doc(inputs):
@@ -94,8 +93,7 @@ def inputs_doc(input_info):
     """
     policy_templates = input_info.get('policy_templates')
     sorted_params = sorted(policy_templates[0].get('vars'), key=lambda v: v['name'])
-    return dict(inp=input_info,
-            sorted_params=sorted_params)
+    return {"inp": input_info, "sorted_params": sorted_params}
 
 local_dir = path.dirname(path.abspath(__file__))
 INTEGRATIONS_DIR = path.expanduser('~/git/integrations/')

--- a/scripts/generator.py
+++ b/scripts/generator.py
@@ -14,11 +14,14 @@ def generate_doc(inputs):
     # inputs.yaml contains extra info on inputs which isn't contained in the manifest.
     # Add this extra info to each input key before generating the docs
     extras = {}
-    with open('inputs.yml', 'r') as extra_f:
+    with open(path.join(local_dir, 'inputs.yml'), 'r') as extra_f:
         extras = yaml.safe_load(extra_f)
     for k in extras.get('inputs').keys():
         if k in inputs.keys():
-            inputs[k]['long_desc'] = extras['inputs'][k]['long_desc']
+            for item in ['long_desc', 'setup_text']:
+                value = extras['inputs'][k].get(item)
+                if value is not None:
+                    inputs[k][item] = extras['inputs'][k][item]
 
     for k,v in inputs.items():
         write(path.join(GENERATE_DIR, f'{k}.md'), inputs_doc(v))

--- a/scripts/inputs.yml
+++ b/scripts/inputs.yml
@@ -71,6 +71,10 @@ inputs:
     long_desc: |
       The `tcp` input package for Elastic establishes a listening TCP socket, allowing Logstash or Elastic Agent to receive and ingest data sent over TCP connections. This input is highly versatile, commonly used for collecting raw log lines,
       events, or other structured data from applications and devices that communicate via the TCP protocol. It supports various codecs for parsing the incoming data and can be configured with SSL for secure communication.
+    setup_text: |
+      To collect logs with the `tcp` input, configure the Listen Address and Listen Port. When deployed with Elastic Agent, the agent will listen for TCP messages on the configured address and port.
+      If a secure TCP connection is used, you may need to specify the SSL details in the `SSL` parameter.
+
 
   udp:
     long_desc: |

--- a/scripts/templates/input_doc.j2
+++ b/scripts/templates/input_doc.j2
@@ -8,37 +8,43 @@
 
 #### Configuration Parameters
 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
 {# iterate over all required fields -#}
 {% for param in sorted_params -%}
 {% if param['show_user'] -%}
-##### {{ param['title'] }}
+{% set row %}
+| {{ param['title'] }}
 {% if param['required'] -%}
-*Required*
-{%- else -%}
-*Optional*
-{% endif %}
-
-*type*: {{ param['type'] }}
-
-*description*: {{ param['description'] }}
+| ![Required](https://img.shields.io/badge/✔-93c93e?style=flat)
+{% else -%}
+| ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat)
+{% endif -%}
+| {{ param['type'] }}
+| {{ param['description'] }}
+{% endset %}
+{{ row | replace("\n", " ") }} |
 {% endif %}
 {% endfor %}
 
-#### Advanced Parameters
+#### Advanced Configuration Parameters
 
+| Parameter |  Required | Type | Description |
+| --- | --- | --- | --- |
 {# iterate over all required fields -#}
 {% for param in sorted_params -%}
-{% if param['show_user'] -%}
-#### {{ param['title'] }}
+{% if not param['show_user'] -%}
+{% set row %}
+| {{ param['title'] }}
 {% if param['required'] -%}
-*Required*
-{%- else -%}
-*Optional*
-{% endif %}
-
-*type*: {{ param['type'] }}
-
-*description*: {{ param['description'] }}
+| ![Required](https://img.shields.io/badge/✔-93c93e?style=flat)
+{% else -%}
+| ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat)
+{% endif -%}
+| {{ param['type'] }}
+| {{ param['description'] }}
+{% endset %}
+{{ row | replace("\n", " ") }} |
 {% endif %}
 {% endfor %}
 

--- a/scripts/templates/input_doc.j2
+++ b/scripts/templates/input_doc.j2
@@ -1,3 +1,4 @@
+{%- import 'macros.j2' as macros -%}
 # {{ inp['title'] }}
 
 {{ inp['long_desc'] }}
@@ -6,6 +7,7 @@
 
 ### Collecting logs from {{ inp['title'] }}
 
+{{ inp['setup_text'] }}
 #### Configuration Parameters
 
 | Parameter |  Required | Type | Description |
@@ -13,17 +15,7 @@
 {# iterate over all required fields -#}
 {% for param in sorted_params -%}
 {% if param['show_user'] -%}
-{% set row %}
-| {{ param['title'] }}
-{% if param['required'] -%}
-| ![Required](https://img.shields.io/badge/✔-93c93e?style=flat)
-{% else -%}
-| ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat)
-{% endif -%}
-| {{ param['type'] }}
-| {{ param['description'] }}
-{% endset %}
-{{ row | replace("\n", " ") }} |
+{{ macros.param_row(param) }}
 {% endif %}
 {% endfor %}
 
@@ -34,17 +26,7 @@
 {# iterate over all required fields -#}
 {% for param in sorted_params -%}
 {% if not param['show_user'] -%}
-{% set row %}
-| {{ param['title'] }}
-{% if param['required'] -%}
-| ![Required](https://img.shields.io/badge/✔-93c93e?style=flat)
-{% else -%}
-| ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat)
-{% endif -%}
-| {{ param['type'] }}
-| {{ param['description'] }}
-{% endset %}
-{{ row | replace("\n", " ") }} |
+{{ macros.param_row(param) }}
 {% endif %}
 {% endfor %}
 

--- a/scripts/templates/macros.j2
+++ b/scripts/templates/macros.j2
@@ -1,0 +1,14 @@
+{# macro - param_row #}
+{%- macro param_row(param) -%}
+{% set row %}
+| {{ param['title'] }}
+{% if param['required'] -%}
+| ![Required](https://img.shields.io/badge/✔-93c93e?style=flat)
+{% else -%}
+| ![Optional](https://img.shields.io/badge/✘-fed10c?style=flat)
+{% endif -%}
+| {{ param['type'] }}
+| {{ param['description'] }}
+{% endset %}
+{{ row | replace("\n", " ") }} |
+{%- endmacro -%}

--- a/streaming.md
+++ b/streaming.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Streaming

--- a/syslog.md
+++ b/syslog.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Syslog

--- a/tcp.md
+++ b/tcp.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from TCP

--- a/udp.md
+++ b/udp.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from UDP

--- a/websocket.md
+++ b/websocket.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Websocket

--- a/winlog.md
+++ b/winlog.md
@@ -1,3 +1,0 @@
-## Setup
-
-### Collecting logs from Winlog


### PR DESCRIPTION
Change the generated files to use tables for the input parameters.

This also adds a `setup_text` which can be used to add some setup instructions for integrations to the generated docs, and loads the integrations info from git instead of assuming the user already has a local copy